### PR TITLE
Fix deduce return type in InvokeWithoutArgsAction action for cpp20

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -816,12 +816,8 @@ struct InvokeMethodWithoutArgsAction {
   Class* const obj_ptr;
   const MethodPtr method_ptr;
 
-#if (defined(_MSVC_LANG) && (_MSVC_LANG > 201703L)) || \
-    (defined(__cplusplus) && (__cplusplus > 201703L))
-  using ReturnType = std::invoke_result_t<MethodPtr, Class*>;
-#else
-  using ReturnType = typename std::result_of<MethodPtr(Class*)>::type;
-#endif
+  using ReturnType =
+      decltype((std::declval<Class*>()->*std::declval<MethodPtr>())());
 
   template <typename... Args>
   ReturnType operator()(const Args&...) const {


### PR DESCRIPTION
Description:
The fix of deduce `InvokeWithoutArgsAction::ReturnType` for builds using cpp20. This is solution with master branch of this fork and also Google repository.

Related to PR:
openvinotoolkit/openvino#22784